### PR TITLE
Allow setting a timeout parameter for requests from the client

### DIFF
--- a/iris_sdk/client.py
+++ b/iris_sdk/client.py
@@ -13,13 +13,14 @@ class Client(object):
 
     def __init__(
             self, url=None, account_id=None, username=None, password=None,
-            filename=None):
+            filename=None, timeout=None):
 
         if url is None:
             url = "https://dashboard.bandwidth.com/api"
 
         self._config = Config(url, account_id, username, password, filename)
         self._rest = RestClient()
+        self._request_timeout = timeout
 
     def _get_uri(self, section=None):
 
@@ -38,7 +39,7 @@ class Client(object):
         return self._rest.request(
                     method, url=self._get_uri(section),
                     auth=(self.config.username, self.config.password),
-                    params=params, data=data, headers=headers)
+                    params=params, data=data, headers=headers, timeout=self._request_timeout)
 
     def delete(self, section=None):
         return self._request("DELETE", section)

--- a/iris_sdk/utils/rest.py
+++ b/iris_sdk/utils/rest.py
@@ -21,7 +21,7 @@ class RestClient(object):
 
     """HTTP requests wrapper"""
 
-    def request(self, method, url, auth, params=None, data=None,headers=None):
+    def request(self, method, url, auth, params=None, data=None, headers=None, timeout=None):
 
         assert method in ("GET", "POST", "DELETE", "PUT")
 
@@ -30,7 +30,7 @@ class RestClient(object):
 
             response = requests.request(method, url, auth=auth,
                 headers=(HEADERS if headers is None else headers),
-                data=data, params=params)
+                data=data, params=params, timeout=timeout)
 
             response.raise_for_status()
 


### PR DESCRIPTION
This adds an optional timeout parameter to the initialization of the client. With this, we can set the timeout when we get the client and it will be passed through to the eventual request.