### PR TITLE
Changing setup.cfg description-file to description_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Changing setup.cfg description-file to description_file -- the new version of setup doesn't accept hyphen anymore