### PR TITLE
Upgrade Flagged Vulnerable Deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-certifi==2019.11.28
+certifi==2026.2.25
 chardet==3.0.4
 future==0.18.2
-idna==2.8
-requests==2.22.0
-urllib3==1.26.5
+idna==3.11
+requests==2.32.4
+urllib3==2.6.3
 mock==3.0.5
 requests-mock==1.7.0
 six==1.13.0


### PR DESCRIPTION
This PR upgrades:
- certifi
- idna
- requests
- urllib3

Once this is merged, I will create another PR in Django for these deps and point the bandwidth-iris version at this release